### PR TITLE
Keep subcommands order.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: objective-c
-osx_image: xcode8
+osx_image: xcode9
 
 script:
 - swift package generate-xcodeproj --enable-code-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: objective-c
 osx_image: xcode9
 
 script:
-- swift package generate-xcodeproj --enable-code-coverage
-- make test
+- swift test -Xswiftc -profile-coverage-mapping -Xswiftc -profile-generate
 
 after_success:
-- bash <(curl -s https://codecov.io/bash)
+- curl -s https://codecov.io/bash > codecov.sh
+- chmod +x codecov.sh
+- ./codecov.sh -f ./default.profraw

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	xcodebuild -project Guaka.xcodeproj -scheme Guaka build test
+	swift test
 
 coverage:
 	slather coverage Guaka.xcodeproj

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "StringScanner",
+        "repositoryURL": "https://github.com/oarrabi/StringScanner.git",
+        "state": {
+          "branch": null,
+          "revision": "246c697efe2f57d9042f58b1b53ace4fddb1efc4",
+          "version": "0.2.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,28 @@
+// swift-tools-version:4.0
 import PackageDescription
 
 let package = Package(
-  name: "Guaka",
-  targets: [
-    Target(name: "Guaka")
-  ],
-  dependencies: [.Package(url: "https://github.com/oarrabi/StringScanner", majorVersion: 0)]
+    name: "Guaka",
+    products: [
+        .library(name: "Guaka", targets: ["Guaka"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/oarrabi/StringScanner.git", from: "0.2.0")
+    ],
+    targets: [
+        .target(
+            name: "Guaka",
+            dependencies: [
+                "StringScanner"
+            ]
+        ),
+
+        .testTarget(
+            name: "GuakaTests",
+            dependencies: [
+                "Guaka"
+            ]
+        )
+    ],
+    swiftLanguageVersions: [4]
 )

--- a/Sources/Guaka/Command/Command+Utilities.swift
+++ b/Sources/Guaka/Command/Command+Utilities.swift
@@ -91,21 +91,21 @@ extension Command {
   ///    let x = Command.name(forUsage: "run [arguments]")
   ///    x //"run"
   static func name(forUsage usage: String) throws -> String {
-    if usage.characters.count == 0 {
+    if usage.count == 0 {
       throw CommandError.wrongCommandUsageString(usage)
     }
 
     var name = ""
     if let index = usage.find(string: " ") {
-      name = usage[usage.startIndex..<index]
+      name = String(usage[usage.startIndex..<index])
     } else {
       name = usage
     }
 
-    if name.characters.count == 0 ||
-      name.characters.contains("/") ||
-      name.characters.contains("\\") ||
-      name.characters.first! == "-" {
+    if name.count == 0 ||
+      name.contains("/") ||
+      name.contains("\\") ||
+      name.first! == "-" {
       throw CommandError.wrongCommandUsageString(usage)
     }
     

--- a/Sources/Guaka/Flag/Flag+Utilities.swift
+++ b/Sources/Guaka/Flag/Flag+Utilities.swift
@@ -19,11 +19,11 @@ extension Flag {
   }
 
   func checkFlagLongName() throws {
-    if longName.characters.contains("-") ||
-      longName.characters.contains(" ") ||
-      longName.characters.contains("/") ||
-      longName.characters.contains("\\") ||
-      longName.characters.count == 0 {
+    if longName.contains("-") ||
+      longName.contains(" ") ||
+      longName.contains("/") ||
+      longName.contains("\\") ||
+      longName.count == 0 {
       throw CommandError.wrongFlagLongName(longName)
     }
   }
@@ -33,12 +33,12 @@ extension Flag {
       return
     }
     
-    if shortName.characters.contains("-") ||
-      shortName.characters.contains(" ") ||
-      shortName.characters.contains("/") ||
-      shortName.characters.contains("\\") ||
-      shortName.characters.count == 0 ||
-      shortName.characters.count > 1 {
+    if shortName.contains("-") ||
+      shortName.contains(" ") ||
+      shortName.contains("/") ||
+      shortName.contains("\\") ||
+      shortName.count == 0 ||
+      shortName.count > 1 {
       throw CommandError.wrongFlagShortName(shortName)
     }
   }

--- a/Sources/Guaka/Flag/Flag.swift
+++ b/Sources/Guaka/Flag/Flag.swift
@@ -109,18 +109,18 @@ public struct Flag: Hashable {
   /// ```
   ///
   /// -----
-  public init(shortName: String? = nil,
-              longName: String,
-              value: FlagValue,
-              description: String,
-              inheritable: Bool = false) {
+  public init<T: FlagValue>(shortName: String? = nil,
+                            longName: String,
+                            value: T,
+                            description: String,
+                            inheritable: Bool = false) {
 
     self.longName = longName
     self.shortName = shortName
     self.value = value
     self.inheritable = inheritable
     self.description = description
-    self.type = type(of: value)
+    self.type = T.self
     self.required = true
   }
 

--- a/Sources/Guaka/Help/CommandHelp.swift
+++ b/Sources/Guaka/Help/CommandHelp.swift
@@ -143,7 +143,7 @@ public struct CommandHelp {
 
   /// Return a command sub commands
   private static func subCommands(command: Command) -> [CommandHelp] {
-    return command.commands.map { CommandHelp(command: $0) }.sorted { $0.name < $1.name }
+    return command.commands.map { CommandHelp(command: $0) }
   }
 
   /// Return a command flags

--- a/Sources/Guaka/Help/FlagHelpGeneratorUtils.swift
+++ b/Sources/Guaka/Help/FlagHelpGeneratorUtils.swift
@@ -19,13 +19,13 @@ enum FlagHelpGeneratorUtils {
 
     let longestFlagName =
       notDeprecatedFlags.map { flagPrintableName(flag: $0) }
-        .sorted { s1, s2 in return s1.characters.count < s2.characters.count}
-        .last!.characters.count
+        .sorted { s1, s2 in return s1.count < s2.count}
+        .last!.count
 
     let names =
       notDeprecatedFlags.map { flag -> String in
         let printableName = flagPrintableName(flag: flag)
-        let diff = longestFlagName - printableName.characters.count
+        let diff = longestFlagName - printableName.count
         let addition = String(repeating: " ", count: diff)
         return "\(printableName)\(addition)  "
     }

--- a/Sources/Guaka/Help/HelpGeneratorDefaults.swift
+++ b/Sources/Guaka/Help/HelpGeneratorDefaults.swift
@@ -146,13 +146,13 @@ extension HelpGenerator {
     }
 
     let availableCommands = commandHelp.subCommands.filter { $0.isDeprecated == false }
-    let sortedCommands = availableCommands.sorted { $0.0.name < $0.1.name }
+    let sortedCommands = availableCommands.sorted { $0.name < $1.name }
 
-    let longestCommand = availableCommands.max(by: { $0.name.characters.count < $1.name.characters.count })
-    let longestCommandLength = longestCommand?.name.characters.count ?? 0
+    let longestCommand = availableCommands.max(by: { $0.name.count < $1.name.count })
+    let longestCommandLength = longestCommand?.name.count ?? 0
     
     let ret = sortedCommands.reduce(["Available Commands:"]) { acc, command in
-      let numberOfSpaces = longestCommandLength - command.name.characters.count
+      let numberOfSpaces = longestCommandLength - command.name.count
       let spaces = String(repeating: " ", count: numberOfSpaces)
       return acc + ["  \(command.name)\(spaces)  \(command.shortDescriptionMessage ?? "")"]
       } + ["\n"]

--- a/Sources/Guaka/Misc/Levenshtein.swift
+++ b/Sources/Guaka/Misc/Levenshtein.swift
@@ -11,8 +11,8 @@ enum Levenshtein {
   static func distance(source: String, target: String) -> Int {
     if source == target { return 0 }
 
-    let sourceLen = source.characters.count
-    let targetLen = target.characters.count
+    let sourceLen = source.count
+    let targetLen = target.count
 
     if sourceLen == 0 { return targetLen }
     if targetLen == 0 { return sourceLen }

--- a/Sources/Guaka/Parsing/ArgTokenType.swift
+++ b/Sources/Guaka/Parsing/ArgTokenType.swift
@@ -117,7 +117,7 @@ extension ArgTokenType {
     let scanner = StringScanner(string: string)
     _ = scanner.drop(length: 1)
 
-    let length = scanner.remainingString.characters.count
+    let length = scanner.remainingString.count
 
     if length <= 0 {
 
@@ -155,14 +155,14 @@ extension ArgTokenType {
   /// Return true for `-abc`
   fileprivate static func isMultiFlag(_ scanner: StringScanner) -> Bool {
     if case .value (let str) = scanner.peek(untilString: "=") {
-      return str.characters.count > 1
+      return str.count > 1
     }
 
-    return scanner.remainingString.characters.count > 1
+    return scanner.remainingString.count > 1
   }
 
   /// Return true if the string has equal. like `-a=1`, `-abc=1` and `--verbose=one`
   fileprivate static func hasEqual(_ string: String) -> Bool {
-    return string.characters.first { $0 == "=" } != nil
+    return string.first { $0 == "=" } != nil
   }
 }

--- a/Tests/GuakaTests/CommandType+Run.swift
+++ b/Tests/GuakaTests/CommandType+Run.swift
@@ -18,8 +18,8 @@ class CommandRunTests: XCTestCase {
   func testItRunsPreRunBeforeRun() {
     var events = [String]()
 
-    git.preRun = { _ in events.append("pre"); return true }
-    git.run = { _ in events.append("run") }
+    git.preRun = { (_,_) in events.append("pre"); return true }
+    git.run = { (_,_) in events.append("run") }
 
     git.execute(commandLineArgs: expand("git"))
 
@@ -29,8 +29,8 @@ class CommandRunTests: XCTestCase {
   func testItPreRunReturnFalseExecutionIsHalted() {
     var events = [String]()
 
-    git.preRun = { _ in events.append("pre"); return false }
-    git.run = { _ in events.append("run") }
+    git.preRun = { (_,_) in events.append("pre"); return false }
+    git.run = { (_,_) in events.append("run") }
 
     git.execute(commandLineArgs: expand("git"))
 
@@ -40,8 +40,8 @@ class CommandRunTests: XCTestCase {
   func testItRunsPostRunAfterRun() {
     var events = [String]()
 
-    git.postRun = { _ in events.append("post"); return false  }
-    git.run = { _ in events.append("run") }
+    git.postRun = { (_,_) in events.append("post"); return false  }
+    git.run = { (_,_) in events.append("run") }
 
     git.execute(commandLineArgs: expand("git"))
 
@@ -51,9 +51,9 @@ class CommandRunTests: XCTestCase {
   func testItCallsPreRunPostInOrder() {
     var events = [String]()
 
-    git.preRun = { _ in events.append("pre"); return true }
-    git.run = { _ in events.append("run") }
-    git.postRun = { _ in events.append("post"); return false  }
+    git.preRun = { (_,_) in events.append("pre"); return true }
+    git.run = { (_,_) in events.append("run") }
+    git.postRun = { (_,_) in events.append("post"); return false  }
 
     git.execute(commandLineArgs: expand("git"))
 
@@ -63,9 +63,9 @@ class CommandRunTests: XCTestCase {
   func testReturingFalseFromPreStopsPostToo() {
     var events = [String]()
 
-    git.preRun = { _ in events.append("pre"); return false }
-    git.run = { _ in events.append("run") }
-    git.postRun = { _ in events.append("post"); return false  }
+    git.preRun = { (_,_) in events.append("pre"); return false }
+    git.run = { (_,_) in events.append("run") }
+    git.postRun = { (_,_) in events.append("post"); return false  }
 
     git.execute(commandLineArgs: expand("git"))
 
@@ -75,9 +75,9 @@ class CommandRunTests: XCTestCase {
   func testItFindsTheInheritablePreRunFromCurrentCommandIfAvailable() {
     var events = [String]()
 
-    show.inheritablePreRun = { _ in events.append("ipre1"); return true }
-    remote.inheritablePreRun = { _ in events.append("ipre2"); return true }
-    git.inheritablePreRun = { _ in events.append("ipre3"); return true }
+    show.inheritablePreRun = { (_,_) in events.append("ipre1"); return true }
+    remote.inheritablePreRun = { (_,_) in events.append("ipre2"); return true }
+    git.inheritablePreRun = { (_,_) in events.append("ipre3"); return true }
 
     let f = show.findAdequateInheritableRun(forPre: true)
     _ = f?(Flags(flags: [:]), [])
@@ -88,8 +88,8 @@ class CommandRunTests: XCTestCase {
     var events = [String]()
 
     show.inheritablePreRun = nil
-    remote.inheritablePreRun = { _ in events.append("ipre2"); return true }
-    git.inheritablePreRun = { _ in events.append("ipre3"); return true }
+    remote.inheritablePreRun = { (_,_) in events.append("ipre2"); return true }
+    git.inheritablePreRun = { (_,_) in events.append("ipre3"); return true }
 
     let f = show.findAdequateInheritableRun(forPre: true)
     _ = f?(Flags(flags: [:]), [])
@@ -101,7 +101,7 @@ class CommandRunTests: XCTestCase {
 
     show.inheritablePreRun = nil
     remote.inheritablePreRun = nil
-    git.inheritablePreRun = { _ in events.append("ipre3"); return true }
+    git.inheritablePreRun = { (_,_) in events.append("ipre3"); return true }
 
     let f = show.findAdequateInheritableRun(forPre: true)
     _ = f?(Flags(flags: [:]), [])
@@ -120,9 +120,9 @@ class CommandRunTests: XCTestCase {
   func testItFindsTheInheritablePostRunFromCurrentCommandIfAvailable() {
     var events = [String]()
 
-    show.inheritablePostRun = { _ in events.append("ipost1"); return true}
-    remote.inheritablePostRun = { _ in events.append("ipost2"); return true}
-    git.inheritablePostRun = { _ in events.append("ipost3"); return true}
+    show.inheritablePostRun = { (_,_) in events.append("ipost1"); return true}
+    remote.inheritablePostRun = { (_,_) in events.append("ipost2"); return true}
+    git.inheritablePostRun = { (_,_) in events.append("ipost3"); return true}
 
     let f = show.findAdequateInheritableRun(forPre: false)
     _ = f?(Flags(flags: [:]), [])
@@ -133,8 +133,8 @@ class CommandRunTests: XCTestCase {
     var events = [String]()
 
     show.inheritablePostRun = nil
-    remote.inheritablePostRun = { _ in events.append("ipost2"); return true}
-    git.inheritablePostRun = { _ in events.append("ipost3"); return true}
+    remote.inheritablePostRun = { (_,_) in events.append("ipost2"); return true}
+    git.inheritablePostRun = { (_,_) in events.append("ipost3"); return true}
 
     let f = show.findAdequateInheritableRun(forPre: false)
     _ = f?(Flags(flags: [:]), [])
@@ -146,7 +146,7 @@ class CommandRunTests: XCTestCase {
 
     show.inheritablePostRun = nil
     remote.inheritablePostRun = nil
-    git.inheritablePostRun = { _ in events.append("ipost3"); return true}
+    git.inheritablePostRun = { (_,_) in events.append("ipost3"); return true}
 
     let f = show.findAdequateInheritableRun(forPre: false)
     _ = f?(Flags(flags: [:]), [])
@@ -165,9 +165,9 @@ class CommandRunTests: XCTestCase {
   func testItRunsInheritablePreRunBeforeRun() {
     var events = [String]()
 
-    git.inheritablePreRun = { _ in events.append("ipre"); return true }
-    git.preRun = { _ in events.append("pre"); return true }
-    git.run = { _ in events.append("run"); }
+    git.inheritablePreRun = { (_,_) in events.append("ipre"); return true }
+    git.preRun = { (_,_) in events.append("pre"); return true }
+    git.run = { (_,_) in events.append("run"); }
 
     git.execute(commandLineArgs: expand("git"))
 
@@ -177,9 +177,9 @@ class CommandRunTests: XCTestCase {
   func testIfInheritablePreRunReturnFalseItAltersExecution() {
     var events = [String]()
 
-    git.inheritablePreRun = { _ in events.append("ipre"); return false }
-    git.preRun = { _ in events.append("pre"); return true }
-    git.run = { _ in events.append("run"); }
+    git.inheritablePreRun = { (_,_) in events.append("ipre"); return false }
+    git.preRun = { (_,_) in events.append("pre"); return true }
+    git.run = { (_,_) in events.append("run"); }
 
     git.execute(commandLineArgs: expand("git"))
 
@@ -189,9 +189,9 @@ class CommandRunTests: XCTestCase {
   func testItRunsInheritablePreRunFromParentBeforeRun() {
     var events = [String]()
 
-    git.inheritablePreRun = { _ in events.append("ipre"); return true }
-    show.preRun = { _ in events.append("pre"); return true }
-    show.run = { _ in events.append("run"); }
+    git.inheritablePreRun = { (_,_) in events.append("ipre"); return true }
+    show.preRun = { (_,_) in events.append("pre"); return true }
+    show.run = { (_,_) in events.append("run"); }
 
     show.execute(commandLineArgs: expand("git"))
 
@@ -201,9 +201,9 @@ class CommandRunTests: XCTestCase {
   func testIfInheritablePreRunFromParentReturnFalseItAltersExecution() {
     var events = [String]()
 
-    git.inheritablePreRun = { _ in events.append("ipre"); return false }
-    show.preRun = { _ in events.append("pre"); return true }
-    show.run = { _ in events.append("run"); }
+    git.inheritablePreRun = { (_,_) in events.append("ipre"); return false }
+    show.preRun = { (_,_) in events.append("pre"); return true }
+    show.run = { (_,_) in events.append("run"); }
 
     show.execute(commandLineArgs: expand("git"))
 
@@ -213,9 +213,9 @@ class CommandRunTests: XCTestCase {
   func testItRunsInheritablePostRunAfterRun() {
     var events = [String]()
 
-    git.inheritablePostRun = { _ in events.append("ipost"); return true}
-    git.postRun = { _ in events.append("post"); return true }
-    git.run = { _ in events.append("run"); }
+    git.inheritablePostRun = { (_,_) in events.append("ipost"); return true}
+    git.postRun = { (_,_) in events.append("post"); return true }
+    git.run = { (_,_) in events.append("run"); }
 
     git.execute(commandLineArgs: expand("git"))
 
@@ -225,9 +225,9 @@ class CommandRunTests: XCTestCase {
   func testIfPostRunReturnFalseItAltersExecutionAndInheritableIsNotCalled() {
     var events = [String]()
 
-    git.inheritablePostRun = { _ in events.append("ipost"); return true}
-    git.postRun = { _ in events.append("post"); return false }
-    git.run = { _ in events.append("run"); }
+    git.inheritablePostRun = { (_,_) in events.append("ipost"); return true}
+    git.postRun = { (_,_) in events.append("post"); return false }
+    git.run = { (_,_) in events.append("run"); }
 
     git.execute(commandLineArgs: expand("git"))
 
@@ -237,9 +237,9 @@ class CommandRunTests: XCTestCase {
   func testItRunsInheritablePostRunParentAfterRun() {
     var events = [String]()
 
-    git.inheritablePostRun = { _ in events.append("ipost"); return true}
-    show.postRun = { _ in events.append("post"); return true }
-    show.run = { _ in events.append("run"); }
+    git.inheritablePostRun = { (_,_) in events.append("ipost"); return true}
+    show.postRun = { (_,_) in events.append("post"); return true }
+    show.run = { (_,_) in events.append("run"); }
 
     show.execute(commandLineArgs: expand("git"))
 
@@ -249,11 +249,11 @@ class CommandRunTests: XCTestCase {
   func testItExecutesAllRuns() {
     var events = [String]()
 
-    git.inheritablePostRun = { _ in events.append("igpost"); return true}
-    show.postRun = { _ in events.append("post"); return true }
-    show.run = { _ in events.append("run"); }
-    remote.inheritablePreRun = { _ in events.append("irpre"); return true }
-    show.preRun = { _ in events.append("pre"); return true }
+    git.inheritablePostRun = { (_,_) in events.append("igpost"); return true}
+    show.postRun = { (_,_) in events.append("post"); return true }
+    show.run = { (_,_) in events.append("run"); }
+    remote.inheritablePreRun = { (_,_) in events.append("irpre"); return true }
+    show.preRun = { (_,_) in events.append("pre"); return true }
 
     show.execute(commandLineArgs: expand("git"))
 
@@ -263,11 +263,11 @@ class CommandRunTests: XCTestCase {
   func testItDoesNotCrashIfSomeRunsAreNotSet() {
     var events = [String]()
 
-    show.inheritablePostRun = { _ in events.append("irpost"); return true}
+    show.inheritablePostRun = { (_,_) in events.append("irpost"); return true}
     show.postRun = nil
-    show.run = { _ in events.append("run"); }
-    git.inheritablePreRun = { _ in events.append("igpre"); return true }
-    show.preRun = { _ in events.append("pre"); return true }
+    show.run = { (_,_) in events.append("run"); }
+    git.inheritablePreRun = { (_,_) in events.append("igpre"); return true }
+    show.preRun = { (_,_) in events.append("pre"); return true }
 
     show.execute(commandLineArgs: expand("git"))
 
@@ -277,11 +277,11 @@ class CommandRunTests: XCTestCase {
   func testIfItHasLotsOfRunsInheritablePreCanStopAllOfThem() {
     var events = [String]()
 
-    git.inheritablePostRun = { _ in events.append("igpost"); return true}
-    show.postRun = { _ in events.append("post"); return true }
-    show.run = { _ in events.append("run"); }
-    remote.inheritablePreRun = { _ in events.append("irpre"); return false }
-    show.preRun = { _ in events.append("pre"); return true }
+    git.inheritablePostRun = { (_,_) in events.append("igpost"); return true}
+    show.postRun = { (_,_) in events.append("post"); return true }
+    show.run = { (_,_) in events.append("run"); }
+    remote.inheritablePreRun = { (_,_) in events.append("irpre"); return false }
+    show.preRun = { (_,_) in events.append("pre"); return true }
 
     show.execute(commandLineArgs: expand("git"))
 
@@ -291,11 +291,11 @@ class CommandRunTests: XCTestCase {
   func testIfItHasLotsOfRunsPreCanStopAllOfThemExceptInheritable() {
     var events = [String]()
 
-    git.inheritablePostRun = { _ in events.append("igpost"); return true}
-    show.postRun = { _ in events.append("post"); return true }
-    show.run = { _ in events.append("run"); }
-    show.inheritablePreRun = { _ in events.append("ispre"); return true }
-    show.preRun = { _ in events.append("pre"); return false }
+    git.inheritablePostRun = { (_,_) in events.append("igpost"); return true}
+    show.postRun = { (_,_) in events.append("post"); return true }
+    show.run = { (_,_) in events.append("run"); }
+    show.inheritablePreRun = { (_,_) in events.append("ispre"); return true }
+    show.preRun = { (_,_) in events.append("pre"); return false }
 
     show.execute(commandLineArgs: expand("git"))
 


### PR DESCRIPTION
Default implementation of `subCommandsSection` in `HelpGenerator` also sort commands by name.
Keep order will enable custom implementation of `subCommandsSection` to utilize this information.