### PR TITLE
Don't recomend getting more information when there are no subcommands

### DIFF
--- a/Sources/Guaka/Help/HelpGeneratorDefaults.swift
+++ b/Sources/Guaka/Help/HelpGeneratorDefaults.swift
@@ -206,7 +206,7 @@ extension HelpGenerator {
   }
 
   public var informationSection: String? {
-    return ["Use \"\(commandHelp.fullName) [command] --help\" for more information about a command."].joined(separator: "\n")
+    return commandHelp.hasSubCommands ? ["Use \"\(commandHelp.fullName) [command] --help\" for more information about a command."].joined(separator: "\n") : nil
   }
 
   public func deprecationMessage(forDeprecatedFlag flag: FlagHelp) -> String? {

--- a/Tests/GuakaTests/HelpGeneratorTests.swift
+++ b/Tests/GuakaTests/HelpGeneratorTests.swift
@@ -17,16 +17,16 @@ class HelpGeneratorTests: XCTestCase {
 
   func testItGeneratesHelpSection() {
     let h1 = DefaultHelpGenerator(command: show)
-    XCTAssertEqual(h1.helpMessage, "Usage:\n  git remote show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy          \n\nGlobal Flags:\n  -d, --debug     \n      --remote    \n  -v, --verbose   \n\nUse \"git remote show [command] --help\" for more information about a command.")
+    XCTAssertEqual(h1.helpMessage, "Usage:\n  git remote show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy          \n\nGlobal Flags:\n  -d, --debug     \n      --remote    \n  -v, --verbose   \n\n")
 
     show.longMessage = "abcd"
     let h2 = DefaultHelpGenerator(command: show)
-    XCTAssertEqual(h2.helpMessage, "abcd\n\nUsage:\n  git remote show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy          \n\nGlobal Flags:\n  -d, --debug     \n      --remote    \n  -v, --verbose   \n\nUse \"git remote show [command] --help\" for more information about a command.")
+    XCTAssertEqual(h2.helpMessage, "abcd\n\nUsage:\n  git remote show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy          \n\nGlobal Flags:\n  -d, --debug     \n      --remote    \n  -v, --verbose   \n\n")
   }
 
   func testItGeneratesErrorHelpSection() {
     let h = DefaultHelpGenerator(command: show)
-    XCTAssertEqual(h.errorHelpMessage, "Usage:\n  git remote show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy          \n\nGlobal Flags:\n  -d, --debug     \n      --remote    \n  -v, --verbose   \n\nUse \"git remote show [command] --help\" for more information about a command.")
+    XCTAssertEqual(h.errorHelpMessage, "Usage:\n  git remote show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy          \n\nGlobal Flags:\n  -d, --debug     \n      --remote    \n  -v, --verbose   \n\n")
   }
 
   func testItGeneratesErrorDeprecationMessage() {
@@ -113,7 +113,9 @@ class HelpGeneratorTests: XCTestCase {
 
   func testItGeneratesInformationSection() {
     let h1 = DefaultHelpGenerator(command: show)
-    XCTAssertEqual(h1.informationSection, ["Use \"git remote show [command] --help\" for more information about a command."].joined(separator: "\n"))
+    XCTAssertNil(h1.informationSection)
+    let h2 = DefaultHelpGenerator(command: git)
+    XCTAssertEqual(h2.informationSection, ["Use \"git [command] --help\" for more information about a command."].joined(separator: "\n"))
   }
 
   func testItGeneratesFlagDeprecationMessage() {

--- a/Tests/GuakaTests/HelpTests.swift
+++ b/Tests/GuakaTests/HelpTests.swift
@@ -90,10 +90,10 @@ class HelpTests: XCTestCase {
 
     show.shortMessage = "Show short usage"
     XCTAssertEqual(show.helpMessage,
-                   "Show short usage\n\nUsage:\n  git remote show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy          \n\nGlobal Flags:\n  -d, --debug     \n      --remote    \n  -v, --verbose   \n\nUse \"git remote show [command] --help\" for more information about a command.")
+                   "Show short usage\n\nUsage:\n  git remote show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy          \n\nGlobal Flags:\n  -d, --debug     \n      --remote    \n  -v, --verbose   \n\n")
 
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  git rebase [flags]\n\nFlags:\n  -v, --varvar   \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"git rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase [flags]\n\nFlags:\n  -v, --varvar   \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\n")
   }
 
   func testItGenerateTheFullHelpEvenIfRequiredFlagsAreMissing() {
@@ -131,20 +131,20 @@ class HelpTests: XCTestCase {
   func testIfAllFlagsAreDeprecatedItDoesNotShowFlags() {
     rebase.flags[0].deprecationStatus = .deprecated("Dont use this")
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  git rebase [flags]\n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"git rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase [flags]\n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\n")
   }
 
   func testItPrintsTheExample() {
     rebase.example = "run git rebase blabla"
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  git rebase [flags]\n\nExamples:\nrun git rebase blabla\n\nFlags:\n  -v, --varvar   \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"git rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase [flags]\n\nExamples:\nrun git rebase blabla\n\nFlags:\n  -v, --varvar   \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\n")
   }
 
   func testItPrintsTheUsageSection() {
     rebase.usage = "rebase bla bla bla"
     XCTAssertEqual(rebase.nameOrEmpty, "rebase")
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  git rebase bla bla bla [flags]\n\nFlags:\n  -v, --varvar   \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"git rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase bla bla bla [flags]\n\nFlags:\n  -v, --varvar   \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\n")
   }
 
   func testItPrintsTheUsageSectionWhenAnAliasIsUsed() {
@@ -152,7 +152,7 @@ class HelpTests: XCTestCase {
     rebase.aliasUsedToCallCommand = "rbase"
     XCTAssertEqual(rebase.nameOrEmpty, "rebase")
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  git rbase bla bla bla [flags]\n\nFlags:\n  -v, --varvar   \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"git rbase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rbase bla bla bla [flags]\n\nFlags:\n  -v, --varvar   \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\n")
   }
 
   func testItDoesNotPrintFlagsIfCommandHaveZeroFlags() {
@@ -185,6 +185,6 @@ class HelpTests: XCTestCase {
     git.commands = []
     git.usage = "git do this"
     XCTAssertEqual(git.helpMessage,
-                   "Usage:\n  git do this\n\nUse \"git [command] --help\" for more information about a command.")
+                   "Usage:\n  git do this\n\n")
   }
 }


### PR DESCRIPTION
Currently, if you run a command with --help and that command has no subcommands, there will be a message printed by the default HelpGenerator that says:
`Use "executable commandName [command] --help" for more information about a command.`

This is not necessary if there are no subcommands.