### PR TITLE
Additions

### DIFF
--- a/Sources/Guaka/Command/Command.swift
+++ b/Sources/Guaka/Command/Command.swift
@@ -386,8 +386,9 @@ public class Command {
     printToConsole(errorMessage ?? helpMessage)
     exit(Int32(statusCode))
   }
-  
+
   /// Print a string to console. This method is for enabling testability only
+  @available(*, deprecated, message: "This method is for enabling testability and as such should only be used in tests.")
   func printToConsole(_ string: String) {
     print(string)
   }
@@ -395,4 +396,23 @@ public class Command {
   func name() throws -> String {
     return try Command.name(forUsage: usage)
   }
+}
+
+/// Fail, print the error message and exit the application
+/// Call this method when you want to exit and print an error message
+///
+/// - parameter statusCode: the status code to report
+/// - parameter errorMessage: additional error message to print
+public func fail(statusCode: Int, errorMessage: String) -> Never {
+  print(errorMessage)
+  exit(Int32(statusCode))
+}
+
+/// Fail, print the help message and exit the application
+/// Call this method when you want to exit and print the help message
+///
+/// - parameter statusCode: the status code to report
+/// - parameter command: the command whose help message should be printed
+public func fail(statusCode: Int, command: Command) -> Never {
+    Guaka.fail(statusCode: statusCode, errorMessage: command.helpMessage)
 }

--- a/Sources/Guaka/Flag/Flags.swift
+++ b/Sources/Guaka/Flag/Flags.swift
@@ -108,4 +108,15 @@ public struct Flags {
     return flagsDict[name]?.value as? T
   }
 
+
+  /// Get an array of values for a type
+  ///
+  /// - parameter name: the flag name
+  /// - parameter type: the array type of the flag
+  ///
+  /// - returns: the values if the flag is found
+  public func get<T: FlagValue>(name: String, type: [T].Type) -> [T]? {
+    return flagsDict[name]?.values as? [T]
+  }
+
 }


### PR DESCRIPTION
Added global fail methods
Discourage direct usage of `printToConsole` by deprecating the method (compiles with a warning)
Added another `get` method to `Flags` to get arrays of values of a flag